### PR TITLE
Fix usage of successMesage in getServices

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ icingaapi.prototype.getServices = function (callback) {
     }
 
     var req = https.request(options, (res) => {
-        res.on('data', (d) => {
+        res.on('data', (successMesage) => {
             state = {
                 "Statuscode": res.statusCode,
                 "StatusMessage": res.statusMessage,


### PR DESCRIPTION
Hi, 
in icingaapi.prototype.getServices the var `d` is used for a data response. It should be `successMesage` while ` "Statecustom": successMesage`.

can you please publish it, so i do not need to use my fork in npm installs. 
Thanks a lot, 
ps.